### PR TITLE
add select team on get chapters

### DIFF
--- a/src/services/BookService/index.ts
+++ b/src/services/BookService/index.ts
@@ -8,21 +8,15 @@ import {ErrorMsgModel} from "../../models/error-handler-service.model";
 import {ErrorHandler} from "../ErrorHandler/index";
 import {BrowserService} from "../BrowserService/index";
 import {CommonService} from "../CommonService/index";
+import {Config, Prompt} from "prompt-sync";
 
 export class BookService implements BookServiceModel {
-    private $errorService: ErrorHandler;
-    private $browserService: BrowserService;
-    private $commonService: CommonService;
-
-    constructor(
-        $errorService: ErrorHandler,
-        $browserService: BrowserService,
-        $commonService: CommonService,
-    ) {
-        this.$errorService = $errorService;
-        this.$browserService = $browserService;
-        this.$commonService = $commonService
-    }
+  constructor(
+    private $errorService: ErrorHandler,
+    private $browserService: BrowserService,
+    private $commonService: CommonService,
+    private $promptSync: (config?: Config) => Prompt
+  ) {}
 
     public async getBookInfo(url: string): Promise<BookInfoModel> {
         const { browser, page } = await this.$browserService.startBrowser();
@@ -75,6 +69,45 @@ export class BookService implements BookServiceModel {
             await chapterButton.click();
         else
             this.$errorService.throwError(ErrorMsgModel.ELEMENT_COULD_NOT_BE_FOUND, 'кнопку для открытия списка глав')
+
+        // Находим див в котором выводятся все доступные команды перевода
+        const teamsDiv = await page.waitForSelector("div.team-list");
+
+        if (teamsDiv) {
+          // Если таковой есть - получаем все варианты, даем выбор в промпту
+          const teamsButtons = await page.evaluate(() => {
+            const data: NodeListOf<HTMLElement> =
+              document.querySelectorAll("div.team-item-wrap");
+            return Array.from(data).map(
+              (elem) =>
+                elem.querySelector("div.team-list-item__name > span")
+                  ?.textContent || "Неизвестно"
+            );
+          });
+          const prompt = this.$promptSync({ sigint: true });
+          console.log(
+            `Найдено ${teamsButtons.length} команд, выберите одну (нужно ввести цыфру)`
+          );
+          teamsButtons.forEach((team, idx) => console.log(`${idx + 1} ` + team.trim()));
+
+          const selectedTeam = prompt({});
+
+          if (+selectedTeam > teamsButtons.length) {
+            this.$errorService.throwError(
+              ErrorMsgModel.ELEMENT_COULD_NOT_BE_FOUND,
+              "выбраную команду"
+            );
+          }
+          
+          const teamButton = await page.waitForSelector(`div.team-item-wrap:nth-child(${+selectedTeam})`)
+          
+          if (teamButton) await teamButton.click();
+          else
+            this.$errorService.throwError(
+              ErrorMsgModel.ELEMENT_COULD_NOT_BE_FOUND,
+              "выбраную команду"
+            );  
+        }
 
         // Собираю все главы с называниями в один массив
         // Со страницы книги, простым путем, это сделать не получится

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -11,7 +11,8 @@ const $commonService = new CommonService(promptSync);
 const $bookService = new BookService(
     $errorService,
     $browserService,
-    $commonService
+    $commonService,
+    promptSync
 )
 
 export {


### PR DESCRIPTION
Добавил возможночть выбора команды перевода при парсинге глав, т.к. у некоторых тайтлах больше 1 команды и он выбирает не ту что нужно, например: https://ranobelib.me/mushoku-tensei-isekai-ittara-honki-dasu-ln/, тут 2 команды в первой все главы во второй только 3 тома, он брал по дефолту вторую почемуто